### PR TITLE
RequestのEntityからServiceまでを実装

### DIFF
--- a/src/main/java/com/rakuten/internship/entity/Request.java
+++ b/src/main/java/com/rakuten/internship/entity/Request.java
@@ -25,10 +25,10 @@ public class Request {
     private String language;
 
     @Column(nullable = false)
-    private String latitude;
+    private float latitude;
 
     @Column(nullable = false)
-    private String longitude;
+    private float longitude;
 
     // TODO file upload
     private String image;

--- a/src/main/java/com/rakuten/internship/entity/Request.java
+++ b/src/main/java/com/rakuten/internship/entity/Request.java
@@ -1,0 +1,37 @@
+package com.rakuten.internship.entity;
+
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Data
+public class Request {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+
+    private String name;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String language;
+
+    @Column(nullable = false)
+    private String latitude;
+
+    @Column(nullable = false)
+    private String longitude;
+
+    // TODO file upload
+    private String image;
+
+    private boolean isSolved;
+}

--- a/src/main/java/com/rakuten/internship/repository/RequestRepository.java
+++ b/src/main/java/com/rakuten/internship/repository/RequestRepository.java
@@ -4,4 +4,5 @@ import com.rakuten.internship.entity.Request;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestRepository extends JpaRepository<Request, Long> {
+    Request findRequestById(final long id);
 }

--- a/src/main/java/com/rakuten/internship/repository/RequestRepository.java
+++ b/src/main/java/com/rakuten/internship/repository/RequestRepository.java
@@ -1,0 +1,7 @@
+package com.rakuten.internship.repository;
+
+import com.rakuten.internship.entity.Request;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequestRepository extends JpaRepository<Request, Long> {
+}

--- a/src/main/java/com/rakuten/internship/service/RequestService.java
+++ b/src/main/java/com/rakuten/internship/service/RequestService.java
@@ -1,0 +1,26 @@
+package com.rakuten.internship.service;
+
+import com.rakuten.internship.entity.Request;
+import com.rakuten.internship.repository.RequestRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class RequestService {
+    private final RequestRepository repository;
+
+    public RequestService(final RequestRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<Request> findAllRequests() {
+        return repository.findAll();
+    }
+
+    public Request findRequestById(final long id) {
+        return repository.findRequestById(id);
+    }
+}

--- a/src/main/java/com/rakuten/internship/service/RequestService.java
+++ b/src/main/java/com/rakuten/internship/service/RequestService.java
@@ -23,4 +23,8 @@ public class RequestService {
     public Request findRequestById(final long id) {
         return repository.findRequestById(id);
     }
+
+    public void save(final Request request) {
+        repository.save(request);
+    }
 }


### PR DESCRIPTION
# やったこと
表題の通り

# 実装メソッド
- `findAll` : DB上の全てのRequestをListで返す
- `findRequestById` : 引数のIDに対応したRequestを返す
- `save` : 引数のRequestをinsertする